### PR TITLE
Update sources via credits file.

### DIFF
--- a/Credits.md
+++ b/Credits.md
@@ -10,8 +10,8 @@
 
 ### Additional thanks
 
-* [jellysquid3](https://github.com/jellysquid3) for creating [Sodium](https://www.curseforge.com/minecraft/mc-mods/sodium), [Lithium](https://www.curseforge.com/minecraft/mc-mods/sodium), [Phosphor](https://www.curseforge.com/minecraft/mc-mods/phosphor) which were my initial inspiration for creating the modpack
-* [LambdAurora](https://github.com/LambdAurora) for creating [the list of Optifine alternatives](https://gist.githubusercontent.com/LambdAurora/1f6a4a99af374ce500f250c6b42e8754/raw/77014f27982eda43689fe888c5686ed9b2843708/optifine_alternatives_fabric.md) which the pack does get some mod ideas from, [LambDynamicLights](https://www.curseforge.com/minecraft/mc-mods/lambdynamiclights) and [LambdaBetterGrass](https://www.curseforge.com/minecraft/mc-mods/lambdabettergrass)
+* [jellysquid3](https://github.com/jellysquid3) for creating [Sodium](https://www.curseforge.com/minecraft/mc-mods/sodium), [Lithium](https://www.curseforge.com/minecraft/mc-mods/lithium), [Phosphor](https://www.curseforge.com/minecraft/mc-mods/phosphor) which were my initial inspiration for creating the modpack
+* [LambdAurora](https://github.com/LambdAurora) for creating [the list of Optifine alternatives](https://lambdaurora.dev/optifine_alternatives) which the pack does get some mod ideas from, [LambDynamicLights](https://www.curseforge.com/minecraft/mc-mods/lambdynamiclights) and [LambdaBetterGrass](https://www.curseforge.com/minecraft/mc-mods/lambdabettergrass)
 * [comp500](https://github.com/comp500) for creating [Jumploader](https://www.curseforge.com/minecraft/mc-mods/jumploader) - a mod that made the modpack possible in Minecraft 1.16.x, [Indium](https://modrinth.com/mod/indium) - mod that provided the rendering API for Sodium for increased mod compatibility and [packwiz](https://github.com/comp500/packwiz) - a tool that makes the MultiMC auto-update and in the future, vanilla installer happen
 * All developers who made the mods that are, have been and will be in the modpack
 * Everyone who uses, tests and shares the modpack!


### PR DESCRIPTION
* Updates the optifine alternatives link to the correct one as the old one was an old gist copy as raw version,
* Corrects the lithium link to it's actual one instead of misleading to sodium's.