### PR TITLE
Replace "current year" -> 2022 in license.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) \<current year\> Fabulously Optimized authors
+Copyright (c) 2022 Fabulously Optimized authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
* Replaces the <current year> text with 2022 as github doesn't seem to translate the <> context very well.

*(edits are welcomed)*