### PR TITLE
Add pre-launch.sh and post-exit.sh

### DIFF
--- a/Packwiz/post-exit.sh
+++ b/Packwiz/post-exit.sh
@@ -3,7 +3,7 @@
 # Edits by RaptaG (https://github.com/RaptaG)
 
 # Restore packwiz disabled mods to prevent useless redownload
-echo Restoring overriden mods for future launches...
+echo Restoring overridden mods for future launches...
 cd mods
 for disabledmod in .*.jar.disabled
 do

--- a/Packwiz/post-exit.sh
+++ b/Packwiz/post-exit.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Should be ran from the post-exit command in instance's settings.
+# Edits by RaptaG (https://github.com/RaptaG)
+
+# Restore packwiz disabled mods to prevent useless redownload
+echo Restoring overriden mods for future launches...
+cd mods
+for disabledmod in .*.jar.disabled
+do
+	mod=$(basename $disabledmod .jar.disabled).jar
+	mv $disabledmod ${mod#.}
+	echo Mods restored successfully!
+done

--- a/Packwiz/post-exit.sh
+++ b/Packwiz/post-exit.sh
@@ -9,5 +9,5 @@ for disabledmod in .*.jar.disabled
 do
 	mod=$(basename $disabledmod .jar.disabled).jar
 	mv $disabledmod ${mod#.}
-	echo Mods restored successfully!
+	echo $mod restored successfully!
 done

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -12,7 +12,13 @@ mod5=
 
 # Upgrade Fabulously Optimized
 echo Checking for FO upgrades...
-mcver="$(curl https://raw.githubusercontent.com/Fabulously-Optimized/fabulously-optimized/main/MultiMC/Fabulously%20Optimized%20x.y.z/mmc-pack.json | jq -r '.components[]|select(.cachedName=="Minecraft")|.version')" 2>/dev/null
+cd ..
+mcver="$(jq -r '.components[]|select(.cachedName=="Minecraft")|.version' mmc-pack.json)"
+if [ -d .minecraft ]; then
+   cd .minecraft
+else
+   cd minecraft
+fi
 "$INST_JAVA" -jar packwiz-installer-bootstrap.jar https://raw.githubusercontent.com/Fabulously-Optimized/fabulously-optimized/main/Packwiz/$mcver/pack.toml
 
 # Upgrading the checksums

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -26,7 +26,6 @@ for mod in\
 	$mod1.jar\
 	$mod2.jar\
 	$mod3.jar\
-	$mod3.jar\
 	$mod4.jar\
 	$mod5.jar\
 	$mod0.jar

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -3,12 +3,12 @@
 # Edits by RaptaG (https://github.com/RaptaG)
 
 # Select the mods you wish to disable:
-mod0=DCCH-1.18.x
-mod1=fabrishot-1.7.0
-mod2=betterbeds-1.2.0
-mod3=fast-chest-1.2+1.18
-mod4=continuity-1.1.0+1.18.2
-mod5=morechathistory-1.18-1.1.0
+mod0=
+mod1=
+mod2=
+mod3=
+mod4=
+mod5=
 
 # Upgrade Fabulously Optimized
 echo Checking for FO upgrades...

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Should be ran from the pre-launch command in instance's settings.
+# Edits by RaptaG (https://github.com/RaptaG)
+
+# Select the mods you wish to disable:
+mod0=DCCH-1.18.x
+mod1=fabrishot-1.7.0
+mod2=betterbeds-1.2.0
+mod3=fast-chest-1.2+1.18
+mod4=continuity-1.1.0+1.18.2
+mod5=morechathistory-1.18-1.1.0
+
+# Upgrade Fabulously Optimized
+echo Checking for FO upgrades...
+mcver="$(curl https://raw.githubusercontent.com/Fabulously-Optimized/fabulously-optimized/main/MultiMC/Fabulously%20Optimized%20x.y.z/mmc-pack.json | jq -r '.components[]|select(.cachedName=="Minecraft")|.version')" 2>/dev/null
+"$INST_JAVA" -jar packwiz-installer-bootstrap.jar https://raw.githubusercontent.com/Fabulously-Optimized/fabulously-optimized/main/Packwiz/$mcver/pack.toml
+
+# Upgrading the checksums
+checksums="$(md5sum packwiz.json | cut -d' ' -f1)"
+echo "$checksums  packwiz.json" | md5sum -c - || exit 1
+
+# Disabling the mods
+echo Disabling mods...
+cd mods
+for mod in\
+	$mod1.jar\
+	$mod2.jar\
+	$mod3.jar\
+	$mod3.jar\
+	$mod4.jar\
+	$mod5.jar\
+	$mod0.jar
+do
+        mv $mod .$(basename $mod .jar).jar.disabled
+        echo Mods disabled successfully!
+done

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -10,7 +10,7 @@ mod3=
 mod4=
 mod5=
 
-# Upgrade Fabulously Optimized
+# Upgrading Fabulously Optimized
 echo Checking for FO upgrades...
 cd ..
 mcver="$(jq -r '.components[]|select(.cachedName=="Minecraft")|.version' mmc-pack.json)"

--- a/Packwiz/pre-launch.sh
+++ b/Packwiz/pre-launch.sh
@@ -37,5 +37,5 @@ for mod in\
 	$mod0.jar
 do
         mv $mod .$(basename $mod .jar).jar.disabled
-        echo Mods disabled successfully!
+        echo $mod disabled successfully!
 done


### PR DESCRIPTION
A new set of scripts for easier mod disabling for MultiMC (auto-update) on Linux and possibly MacOS. Feel free to port them to Windows as well.

Usage tutorial: https://github.com/RaptaG/wiki/blob/main/en-us/multimc-auto-update.md#can-i-ignore-some-of-the-mods