### PR TITLE
Enable two bug fixes in Debugify

### DIFF
--- a/Packwiz/1.19.2/config/debugify.json
+++ b/Packwiz/1.19.2/config/debugify.json
@@ -1,1 +1,1 @@
-{"MC-89146":true,"MC-90683":true,"MC-121772":true,"MC-122477":true,"MC-140646":true,"MC-162253":true,"MC-199467":true,"MC-235035":true,"MC-237493":true,"MC-249059":true,"opt_out_updater":true,"gameplay_fixes_in_multiplayer":false,"default_disabled":true}
+{"MC-89146":true,"MC-90683":true,"MC-112730":true,"MC-121772":true,"MC-122477":true,"MC-140646":true,"MC-162253":true,"MC-199467":true,"MC-228976":true,"MC-235035":true,"MC-237493":true,"MC-249059":true,"opt_out_updater":true,"gameplay_fixes_in_multiplayer":false,"default_disabled":true}


### PR DESCRIPTION
Apparently there's two fixes in Debugify that the wiki [says is enabled](https://fabulously-optimized.gitbook.io/modpack/readme/changed-options#fixed-bugs) but aren't actually enabled. We were talking about this [on Discord](https://discord.com/channels/859124104644788234/1017125874774065283/1018555658032922674) ([via](https://discord.gg/yxaXtaQqdB)), so here's a fix.