### PR TITLE
Disable world border listeners as they memory leak.

### DIFF
--- a/Packwiz/1.19.1/config/yosbr/config/lithium.properties
+++ b/Packwiz/1.19.1/config/yosbr/config/lithium.properties
@@ -1,0 +1,2 @@
+util.world_border_listener=false
+world.block_entity_ticking.world_border=false

--- a/Packwiz/1.19.2/config/yosbr/config/lithium.properties
+++ b/Packwiz/1.19.2/config/yosbr/config/lithium.properties
@@ -1,0 +1,2 @@
+util.world_border_listener=false
+world.block_entity_ticking.world_border=false


### PR DESCRIPTION
The original fix can be found [here](https://github.com/CaffeineMC/lithium-fabric/commit/b4c0e062ca9b3bb2baf2b1f77cc621108c9bbd6b), This issue seems to date back to 1.19.1 aswell at this time.