### PR TITLE
Update fabric loader to 0.14.14.

### DIFF
--- a/CurseForge/manifest.json
+++ b/CurseForge/manifest.json
@@ -3,7 +3,7 @@
     "version": "1.19.3",
     "modLoaders": [
       {
-        "id": "fabric-0.14.13",
+        "id": "fabric-0.14.14",
         "primary": true
       }
     ]

--- a/Modrinth/modrinth.index.json
+++ b/Modrinth/modrinth.index.json
@@ -571,6 +571,6 @@
     ],
     "dependencies": {
         "minecraft": "1.19.3",
-        "fabric-loader": "0.14.13"
+        "fabric-loader": "0.14.14"
     }
 }

--- a/MultiMC/Fabulously Optimized x.y.z/mmc-pack.json
+++ b/MultiMC/Fabulously Optimized x.y.z/mmc-pack.json
@@ -43,9 +43,9 @@
                     "uid": "net.fabricmc.intermediary"
                 }
             ],
-            "cachedVersion": "0.14.13",
+            "cachedVersion": "0.14.14",
             "uid": "net.fabricmc.fabric-loader",
-            "version": "0.14.13"
+            "version": "0.14.14"
         }
     ],
     "formatVersion": 1

--- a/Packwiz/1.19.3/pack.toml
+++ b/Packwiz/1.19.3/pack.toml
@@ -9,5 +9,5 @@ hash-format = "sha256"
 hash = "403512cf838f478d9b3b162430cd9154b175f7cea65214a5560a8ca34945dbf3"
 
 [versions]
-fabric = "0.14.13"
+fabric = "0.14.14"
 minecraft = "1.19.3"


### PR DESCRIPTION
Updates the fabric loader to be on 0.14.14; This resolves modded keybindings not showing properly in controls menu,
This loader version can be backported all the way to 1.16.5 as there are no compatibility issues there if needed.
