### PR TITLE
Add friendly name for git-repo-sync, Filter auto-publish to FO only.

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -28,6 +28,7 @@ jobs:
            game-versions: ${{ vars.MC_VERSION }}
            
   publish-to-modrinth:
+    if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-22.04
     environment: github-actions
     steps:

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -4,6 +4,7 @@ on:
     types: [published]
 jobs:
   publish-to-curseforge:
+    if: github.repository_owner == 'Fabulously-Optimized'
     runs-on: ubuntu-22.04
     environment: github-actions
     steps:
@@ -38,7 +39,6 @@ jobs:
            latest: true
            tarBall: false
            zipBall: false
-           
            
        - name: Publish to Modrinth
          uses: Kir-Antipov/mc-publish@v3.3

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -1,4 +1,3 @@
-# https://github.com/marketplace/actions/git-repo-sync
 name: Git Repo Sync
 
 on: 
@@ -11,10 +10,12 @@ jobs:
     runs-on: ubuntu-22.04
     name: Git Repo Sync - BitBucket
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout the Repository
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
-    - uses: wangchucheng/git-repo-sync@v0.1.0
+    - name: Synchronize code to other Git platforms
+      uses: wangchucheng/git-repo-sync@v0.1.0
       with:
         target-url: ${{ secrets.BITBUCKET_GIT }}
         target-username: ${{ secrets.BITBUCKET_USERNAME }}


### PR DESCRIPTION
Auto-Publish has been updated to now only execute when the commit is done on the fabulously optimized organization,
and finally the git-repo-sync program will now be using friendly names in job applications to betterly describe them.