### PR TITLE
Fix a bug in dirt_path.json

### DIFF
--- a/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
+++ b/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
@@ -1,34 +1,33 @@
 {
-    "parent": "block/block",
-    "textures": {
-        "particle": "block/dirt",
-        "top": "block/dirt_path_top",
-        "bottom": "block/dirt"
+  "parent": "block/block",
+  "textures": {
+    "particle": "block/dirt",
+    "top": "block/dirt_path_top",
+    "bottom": "block/dirt"
+  },
+  "elements": [
+    {
+      "from": [0, 0, 0],
+      "to": [16, 15, 16],
+      "faces": {
+        "down": { "uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" },
+        "up": { "uv": [0, 0, 16, 16], "texture": "#top" },
+        "north": { "uv": [0, 0, 16, 15], "texture": "#top", "cullface": "north" },
+        "south": { "uv": [0, 0, 16, 15], "texture": "#top", "cullface": "south" },
+        "west": { "uv": [0, 0, 16, 15], "texture": "#top", "cullface": "west" },
+        "east": { "uv": [0, 0, 16, 15], "texture": "#top", "cullface": "east" }
+      }
     },
-    
-    "elements": [
-        {   "from": [ -0.008, -1, -0.008 ],
-            "to": [ 16.008, 15, 16.008 ],
-            "faces": {  
-                "down":  { "uv": [ 0, 0, 16, 16 ], "texture": "#bottom", "cullface": "down" },
-                "up":    { "uv": [ 0, 0, 16, 16 ], "texture": "#top" },
-                "north": { "uv": [ 0, 1, 16.008, 16.008 ], "texture": "#top", "cullface": "north" },
-                "south": { "uv": [ 0, 1, 16.008, 16.008 ], "texture": "#top", "cullface": "south" },
-                "west":  { "uv": [ 0, 1, 16.008, 16.008 ], "texture": "#top", "cullface": "west" },
-                "east":  { "uv": [ 0, 1, 16.008, 16.008 ], "texture": "#top", "cullface": "east" }
-            }
-        },
-		{
-			"from": [0, -0, 0],
-			"to": [16, -0.0001, 16],
-			"faces": {
-				"north": {"uv": [0, 0, 16, 0], "texture": "#bottom", "cullface": "down" },
-				"east": {"uv": [0, 0, 16, 0], "texture": "#bottom", "cullface": "down" },
-				"south": {"uv": [0, 0, 16, 0], "texture": "#bottom", "cullface": "down" },
-				"west": {"uv": [0, 0, 16, 0], "texture": "#bottom", "cullface": "down" },
-				"up": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" },
-				"down": {"uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" }
-			}
-		}
-    ]
+    {
+      "from": [-0.008, -1, -0.008],
+      "to": [16.008, 0, 16.008],
+      "faces": {
+        "north": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
+        "east": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
+        "south": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
+        "west": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
+        "down": { "uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" }
+      }
+    }
+  ]
 }

--- a/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
+++ b/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
@@ -22,10 +22,10 @@
       "from": [-0.008, -1, -0.008],
       "to": [16.008, 0, 16.008],
       "faces": {
-        "north": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
-        "east": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
-        "south": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
-        "west": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "down" },
+        "north": { "uv": [0, 15, 16, 16], "texture": "#top"},
+        "east": { "uv": [0, 15, 16, 16], "texture": "#top" },
+        "south": { "uv": [0, 15, 16, 16], "texture": "#top" },
+        "west": { "uv": [0, 15, 16, 16], "texture": "#top" },
         "down": { "uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" }
       }
     }

--- a/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
+++ b/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
@@ -27,16 +27,6 @@
         "south": { "uv": [0, 15, 16, 16], "texture": "#top" , "cullface": "south"},
         "west": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "west" }
       }
-    },
-    {
-      "from": [16.008, 0, 16.008],
-      "to": [-0.008, -1, -0.008],
-      "faces": {
-        "north": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down" },
-        "east": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down"  },
-        "south": { "uv": [0, 16, 16, 15], "texture": "#top" , "cullface": "down"},
-        "west": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down" }
-      }
     }
   ]
 }

--- a/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
+++ b/Resource Packs/Fast Better Grass/assets/minecraft/models/block/dirt_path.json
@@ -22,11 +22,20 @@
       "from": [-0.008, -1, -0.008],
       "to": [16.008, 0, 16.008],
       "faces": {
-        "north": { "uv": [0, 15, 16, 16], "texture": "#top"},
-        "east": { "uv": [0, 15, 16, 16], "texture": "#top" },
-        "south": { "uv": [0, 15, 16, 16], "texture": "#top" },
-        "west": { "uv": [0, 15, 16, 16], "texture": "#top" },
-        "down": { "uv": [0, 0, 16, 16], "texture": "#bottom", "cullface": "down" }
+        "north": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "north" },
+        "east": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "east"  },
+        "south": { "uv": [0, 15, 16, 16], "texture": "#top" , "cullface": "south"},
+        "west": { "uv": [0, 15, 16, 16], "texture": "#top", "cullface": "west" }
+      }
+    },
+    {
+      "from": [16.008, 0, 16.008],
+      "to": [-0.008, -1, -0.008],
+      "faces": {
+        "north": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down" },
+        "east": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down"  },
+        "south": { "uv": [0, 16, 16, 15], "texture": "#top" , "cullface": "down"},
+        "west": { "uv": [0, 16, 16, 15], "texture": "#top", "cullface": "down" }
       }
     }
   ]


### PR DESCRIPTION
The old file causes a bug when the side touches a block, it will cull and make a 16\*1 pixel gap.
![before](https://github.com/Fabulously-Optimized/fabulously-optimized/assets/107340726/5b383713-ef30-42a1-b19c-47233914cf68)
I fixed it by removing the lower "down" face to fix it.
![remove_down](https://github.com/Fabulously-Optimized/fabulously-optimized/assets/107340726/0ad097a8-c0c5-4adb-be85-226527d36471)
Other choices:
- Removing the extra box.
  [dirt_path.json](https://github.com/Fabulously-Optimized/fabulously-optimized/files/13290645/dirt_path.json)
- Removing the lower "down" face and add 4 faces inside cull like side
  [dirt_path.json](https://github.com/Fabulously-Optimized/fabulously-optimized/files/13290650/dirt_path.json)
- Removing the lower "down" face and add 4 faces inside cull like down
  [dirt_path.json](https://github.com/Fabulously-Optimized/fabulously-optimized/files/13290651/dirt_path.json)


<!--
Thanks for submitting a pull request!

- Translation PRs are not accepted, use Crowdin instead: https://fabulously-optimized.gitbook.io/modpack/readme/language-support#modpack
- Mod and config changes are not accepted, use issues to propose them: https://github.com/Fabulously-Optimized/fabulously-optimized/issues
- Major changes should be discussed as an issue or on Discord first.

-->
