### PR TITLE
Update release-downloader to 1.9, Remove "the" from step names

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-22.04
     environment: github-actions
     steps:
-       - name: Download the pack files
-         uses: robinraju/release-downloader@v1.8
+       - name: Download pack files
+         uses: robinraju/release-downloader@v1.9
          id: download-files
          with:
            fileName: "*.zip"
@@ -32,8 +32,8 @@ jobs:
     runs-on: ubuntu-22.04
     environment: github-actions
     steps:
-       - name: Download the pack files
-         uses: robinraju/release-downloader@v1.8
+       - name: Download pack files
+         uses: robinraju/release-downloader@v1.9
          id: download-files
          with:
            fileName: "*.mrpack"

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     name: Git Repo Sync - BitBucket
     steps:
-    - name: Checkout the Repository
+    - name: Checkout Repository
       uses: actions/checkout@v4
       with:
         fetch-depth: 0


### PR DESCRIPTION
1. Updates the release-downloader job to 1.9 - Release notes can be found [here](https://github.com/robinraju/release-downloader/releases/tag/v1.9),
2. Removes the word "the" from checkout step and download step as it's too bizarre.
