### PR TITLE
Update Ubuntu to 24.04

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -5,7 +5,7 @@ on:
 jobs:
   publish-to-curseforge:
     if: github.repository_owner == 'Fabulously-Optimized'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: github-actions
     steps:
        - name: Download pack files

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   sync-bitbucket:
     if: github.repository_owner == 'Fabulously-Optimized'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Git Repo Sync - BitBucket
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
GitHub pushed a new blog stating that `ubuntu-24.04` can now be used as `runs-on` version, Check the blog [here](https://github.blog/changelog/2024-05-14-github-hosted-runners-public-beta-of-ubuntu-24-04-is-now-available).

Extra note: This PR can be copied over to the `fabulously-web` as no other changes are needed there if merged.