### PR TITLE
Update Ubuntu to 24.04 in publish section

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -30,7 +30,7 @@ jobs:
            
   publish-to-modrinth:
     if: github.repository_owner == 'Fabulously-Optimized'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment: github-actions
     permissions:
       id-token: write


### PR DESCRIPTION
Updates Ubuntu to 24.04 in modrinth's publishing section as this was probably missed, Also 24.04 is out of beta.