### PR TITLE
Use proper name for download-artifact

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -44,7 +44,7 @@ jobs:
        - name: Download packwiz
          uses: actions/download-artifact@v4
          with:
-           name: "Linux 64-bit x86"
+           name: "Linux x86_64"
            github-token: ${{ secrets.GH_PAT }}
            repository: packwiz/packwiz
            run-id: 12858009936


### PR DESCRIPTION
"64-bit x86" is never actually said by mostly all linux package managers.
