### PR TITLE
Checkout v5 for workflows

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -38,7 +38,7 @@ jobs:
       contents: write
     steps:
        - name: Checkout Repository
-         uses: actions/checkout@v4
+         uses: actions/checkout@v5
          with:
            persist-credentials: false
        - name: Download packwiz

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -11,9 +11,8 @@ jobs:
     name: Git Repo Sync - BitBucket
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
-        fetch-depth: 0
         persist-credentials: false
     - name: Synchronize code to other Git platforms
       uses: wangchucheng/git-repo-sync@v0.1.0


### PR DESCRIPTION
Updates checkout to v5 for both workflows. *(and also removes fetch-depth as it isn't important)*

This checkout step makes use of Node 24 but otherwise this change is minor.